### PR TITLE
Actor serialization fixes

### DIFF
--- a/actor/manager/container.go
+++ b/actor/manager/container.go
@@ -79,7 +79,7 @@ func NewDefaultActorContainerContext(ctx context.Context, actorID string, impl a
 	impl.SetID(actorID)
 	daprClient, _ := dapr.NewClient()
 	// create state manager for this new actor
-	impl.SetStateManager(state.NewActorStateManagerContext(impl.Type(), actorID, state.NewDaprStateAsyncProvider(daprClient)))
+	impl.SetStateManager(state.NewActorStateManagerContext(impl.Type(), actorID, state.NewDaprStateAsyncProviderWithSerializer(daprClient, serializer)))
 	// save state of this actor
 	err := impl.SaveState(ctx)
 	if err != nil {

--- a/actor/state/state_async_provider.go
+++ b/actor/state/state_async_provider.go
@@ -114,6 +114,10 @@ func (d *DaprStateAsyncProvider) ApplyContext(ctx context.Context, actorType, ac
 // TODO(@laurence) the daprClient may be nil.
 func NewDaprStateAsyncProvider(daprClient client.Client) *DaprStateAsyncProvider {
 	stateSerializer, _ := codec.GetActorCodec(constant.DefaultSerializerType)
+	return NewDaprStateAsyncProviderWithSerializer(daprClient, stateSerializer)
+}
+
+func NewDaprStateAsyncProviderWithSerializer(daprClient client.Client, stateSerializer codec.Codec) *DaprStateAsyncProvider {
 	return &DaprStateAsyncProvider{
 		stateSerializer: stateSerializer,
 		daprClient:      daprClient,

--- a/client/actor.go
+++ b/client/actor.go
@@ -15,7 +15,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -400,7 +399,7 @@ func (c *GRPCClient) makeCallProxyFunction(actor actor.Client, methodName string
 
 		var data []byte
 		if len(inIArr) > 0 {
-			data, err = json.Marshal(inIArr[0])
+			data, err = serializer.Marshal(inIArr[0])
 		}
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
- Add an option to set state serialization codec
- Use the same serialization codec for saving actor state as the actor request serialization
- Fix client request proxy call to use the configured serialization codec when encoding request payload.