### PR TITLE
Feature: add function to shut down all local actors

### DIFF
--- a/actor/manager/manager.go
+++ b/actor/manager/manager.go
@@ -44,6 +44,7 @@ type ActorManagerContext interface {
 	DeactivateActor(ctx context.Context, actorID string) actorErr.ActorErr
 	InvokeReminder(ctx context.Context, actorID, reminderName string, params []byte) actorErr.ActorErr
 	InvokeTimer(ctx context.Context, actorID, timerName string, params []byte) actorErr.ActorErr
+	Shutdown(ctx context.Context)
 }
 
 // DefaultActorManagerContext is to manage one type of actor.
@@ -215,6 +216,13 @@ func (m *DefaultActorManagerContext) InvokeTimer(ctx context.Context, actorID, t
 	}
 	_, aerr = actorContainer.Invoke(ctx, timerParams.CallBack, timerParams.Data)
 	return aerr
+}
+
+func (m *DefaultActorManagerContext) Shutdown(ctx context.Context) {
+	m.activeActors.Range(func(key, value interface{}) bool {
+		value.(ActorContainerContext).GetActor().Shutdown(ctx)
+		return true
+	})
 }
 
 func getAbsctractMethodMap(rcvr interface{}) (map[string]*MethodType, error) {

--- a/actor/runtime/actor_runtime.go
+++ b/actor/runtime/actor_runtime.go
@@ -125,6 +125,13 @@ func (r *ActorRunTimeContext) InvokeTimer(ctx context.Context, actorTypeName, ac
 	return mng.InvokeTimer(ctx, actorID, timerName, params)
 }
 
+func (r *ActorRunTimeContext) Shutdown(ctx context.Context) {
+	r.actorManagers.Range(func(key, value interface{}) bool {
+		value.(manager.ActorManagerContext).Shutdown(ctx)
+		return true
+	})
+}
+
 // Deprecated: use ActorRunTimeContext instead.
 func (r *ActorRunTime) RegisterActorFactory(f actor.Factory, opt ...config.Option) {
 	r.ctx.RegisterActorFactory(func() actor.ServerContext { return f().WithContext() }, opt...)

--- a/service/http/service.go
+++ b/service/http/service.go
@@ -90,6 +90,14 @@ func (s *Server) GracefulStop() error {
 	return s.Stop()
 }
 
+func (s *Server) GracefullShutdownActors() error {
+	ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	runtime.GetActorRuntimeInstanceContext().Shutdown(ctxShutDown)
+	return nil
+}
+
 func setOptions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST,OPTIONS")

--- a/service/http/service.go
+++ b/service/http/service.go
@@ -103,6 +103,8 @@ func (s *Server) Stop() error {
 }
 
 func (s *Server) GracefulStop() error {
+	s.GracefullShutdownActors()
+
 	return s.Stop()
 }
 

--- a/service/http/service.go
+++ b/service/http/service.go
@@ -103,17 +103,16 @@ func (s *Server) Stop() error {
 }
 
 func (s *Server) GracefulStop() error {
-	s.GracefullShutdownActors()
+	s.gracefulShutdownActors()
 
 	return s.Stop()
 }
 
-func (s *Server) GracefullShutdownActors() error {
+func (s *Server) gracefulShutdownActors() {
 	ctxShutDown, cancel := context.WithTimeout(context.Background(), s.actorShutdownTimeout)
 	defer cancel()
 
 	runtime.GetActorRuntimeInstanceContext().Shutdown(ctxShutDown)
-	return nil
 }
 
 func setOptions(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

- Add function to allow service to shut down all local actors

## Why

- Dapr doesn't automatically deactivate actors when a pod goes down, so we need to shut them down manually