### PR TITLE
Fix protobuf deserializer again

### DIFF
--- a/actor/codec/impl/protobuf.go
+++ b/actor/codec/impl/protobuf.go
@@ -40,9 +40,14 @@ func (c *ProtobufCodec) Unmarshal(data []byte, v interface{}) error {
 
 	targetType := vValue.Elem().Type()
 
-	newObjValue := reflect.New(targetType.Elem())
+	newObj := false
+	var newObjValue reflect.Value
 
-	v = newObjValue.Interface()
+	if targetType.Kind() == reflect.Pointer {
+		newObjValue = reflect.New(targetType.Elem())
+		v = newObjValue.Interface()
+		newObj = true
+	}
 
 	m, ok := v.(proto.Message)
 	if !ok {
@@ -54,7 +59,9 @@ func (c *ProtobufCodec) Unmarshal(data []byte, v interface{}) error {
 		return err
 	}
 
-	vValue.Elem().Set(newObjValue)
+	if newObj {
+		vValue.Elem().Set(newObjValue)
+	}
 
 	return nil
 }

--- a/actor/codec/impl/protobuf_test.go
+++ b/actor/codec/impl/protobuf_test.go
@@ -20,14 +20,29 @@ func TestProtobufMarshal(t *testing.T) {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 
-	var outObj *sample.Sample
+	t.Run("pass pointer to nil value pointer", func(t *testing.T) {
+		var outObj *sample.Sample
 
-	err = c.Unmarshal(bytes, &outObj)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
-	}
+		err = c.Unmarshal(bytes, &outObj)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
 
-	if !proto.Equal(inObj, outObj) {
-		t.Error("input and output does not match")
-	}
+		if !proto.Equal(inObj, outObj) {
+			t.Error("input and output does not match")
+		}
+	})
+
+	t.Run("pass pointer to proto.Message struct", func(t *testing.T) {
+		outObj := &sample.Sample{}
+
+		err = c.Unmarshal(bytes, outObj)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
+
+		if !proto.Equal(inObj, outObj) {
+			t.Error("input and output does not match")
+		}
+	})
 }


### PR DESCRIPTION
Actor invocation passes nil pointers to structs and expect them to be allocated by the deserializer, but the state manager passes pointers to structs. We need to handle both cases.