### PR TITLE
Fix: always use json as timer and reminder encoding

### DIFF
--- a/actor/manager/manager.go
+++ b/actor/manager/manager.go
@@ -15,6 +15,7 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -182,7 +183,7 @@ func (m *DefaultActorManagerContext) InvokeReminder(ctx context.Context, actorID
 		return actorErr.ErrActorFactoryNotSet
 	}
 	reminderParams := &api.ActorReminderParams{}
-	if err := m.serializer.Unmarshal(params, reminderParams); err != nil {
+	if err := json.Unmarshal(params, reminderParams); err != nil {
 		log.Printf("failed to unmarshal reminder param, err: %v ", err)
 		return actorErr.ErrRemindersParamsInvalid
 	}
@@ -205,7 +206,7 @@ func (m *DefaultActorManagerContext) InvokeTimer(ctx context.Context, actorID, t
 		return actorErr.ErrActorFactoryNotSet
 	}
 	timerParams := &api.ActorTimerParam{}
-	if err := m.serializer.Unmarshal(params, timerParams); err != nil {
+	if err := json.Unmarshal(params, timerParams); err != nil {
 		log.Printf("failed to unmarshal reminder param, err: %v ", err)
 		return actorErr.ErrTimerParamsInvalid
 	}


### PR DESCRIPTION
## What

- instead of using the actor encoding always us json for encoding timer and reminder parameters

## Why

- this breaks timers and reminders when using other encodings, e.g. protobuf
- change was introduced upstream which only supports json encoding